### PR TITLE
Update view order and add wrapping

### DIFF
--- a/src/main/java/nusconnect/ui/PersonCard.java
+++ b/src/main/java/nusconnect/ui/PersonCard.java
@@ -47,7 +47,14 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        phone.setText(person.getPhone().map(p -> p.value).orElse(""));
+
+        String phoneText = person.getPhone().map(p -> p.value).orElse("");
+        phone.setText(phoneText);
+        if (phoneText.isEmpty()) {
+            phone.setVisible(false);
+            phone.setManaged(false);
+        }
+
         telegram.setText(person.getTelegram().value);
         person.getModules().stream()
                 .sorted(Comparator.comparing(tag -> tag.moduleName))

--- a/src/main/java/nusconnect/ui/PersonCard.java
+++ b/src/main/java/nusconnect/ui/PersonCard.java
@@ -50,10 +50,8 @@ public class PersonCard extends UiPart<Region> {
 
         String phoneText = person.getPhone().map(p -> p.value).orElse("");
         phone.setText(phoneText);
-        if (phoneText.isEmpty()) {
-            phone.setVisible(false);
-            phone.setManaged(false);
-        }
+        phone.setVisible(!phoneText.isEmpty());
+        phone.setManaged(!phoneText.isEmpty());
 
         telegram.setText(person.getTelegram().value);
         person.getModules().stream()

--- a/src/main/java/nusconnect/ui/PersonDetailsPanel.java
+++ b/src/main/java/nusconnect/ui/PersonDetailsPanel.java
@@ -61,12 +61,12 @@ public class PersonDetailsPanel extends UiPart<Region> {
         if (person != null) {
             nameLabel.setText(person.getName().fullName);
             telegramLabel.setText(person.getTelegram().value);
-            phoneLabel.setText(person.getPhone().map(p -> p.value).orElse(""));
-            emailLabel.setText(person.getEmail().map(e -> e.value).orElse(""));
-            aliasLabel.setText(person.getAlias().map(a -> a.value).orElse(""));
-            courseLabel.setText(person.getCourse().map(c -> c.value).orElse(""));
-            noteLabel.setText(person.getNote().map(n -> n.value).orElse(""));
-            websiteLabel.setText(person.getWebsite().map(w -> w.value).orElse(""));
+            phoneLabel.setText(person.getPhone().map(p -> p.value).orElse("-"));
+            emailLabel.setText(person.getEmail().map(e -> e.value).orElse("-"));
+            aliasLabel.setText(person.getAlias().map(a -> a.value).orElse("-"));
+            courseLabel.setText(person.getCourse().map(c -> c.value).orElse("-"));
+            noteLabel.setText(person.getNote().map(n -> n.value).orElse("-"));
+            websiteLabel.setText(person.getWebsite().map(w -> w.value).orElse("-"));
         } else {
             setDefaultDetails();
         }

--- a/src/main/resources/view/PersonDetailsPanel.fxml
+++ b/src/main/resources/view/PersonDetailsPanel.fxml
@@ -8,6 +8,10 @@
     <Label fx:id="nameLabel" styleClass="person-header-label" />
     <VBox spacing="8" VBox.vgrow="NEVER">
         <HBox spacing="5">
+            <Label text="Telegram:" styleClass="detail-label-bold" />
+            <Label fx:id="telegramLabel" styleClass="detail-label" />
+        </HBox>
+        <HBox spacing="5">
             <Label text="Number:" styleClass="detail-label-bold" />
             <Label fx:id="phoneLabel" styleClass="detail-label" />
         </HBox>
@@ -26,10 +30,6 @@
         <HBox spacing="5">
             <Label text="Note:" styleClass="detail-label-bold" />
             <Label fx:id="noteLabel" styleClass="detail-label" />
-        </HBox>
-        <HBox spacing="5">
-            <Label text="Telegram:" styleClass="detail-label-bold" />
-            <Label fx:id="telegramLabel" styleClass="detail-label" />
         </HBox>
         <HBox spacing="5">
             <Label text="Website:" styleClass="detail-label-bold" />

--- a/src/main/resources/view/PersonDetailsPanel.fxml
+++ b/src/main/resources/view/PersonDetailsPanel.fxml
@@ -5,35 +5,35 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-    <Label fx:id="nameLabel" styleClass="person-header-label" />
+    <Label fx:id="nameLabel" styleClass="person-header-label" wrapText="true" maxWidth="270"/>
     <VBox spacing="8" VBox.vgrow="NEVER">
         <HBox spacing="5">
             <Label text="Telegram:" styleClass="detail-label-bold" />
-            <Label fx:id="telegramLabel" styleClass="detail-label" />
+            <Label fx:id="telegramLabel" styleClass="detail-label" wrapText="true" maxWidth="240"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Number:" styleClass="detail-label-bold" />
-            <Label fx:id="phoneLabel" styleClass="detail-label" />
+            <Label fx:id="phoneLabel" styleClass="detail-label" wrapText="true" maxWidth="250"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Email:" styleClass="detail-label-bold" />
-            <Label fx:id="emailLabel" styleClass="detail-label" />
+            <Label fx:id="emailLabel" styleClass="detail-label" wrapText="true" maxWidth="270"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Alias:" styleClass="detail-label-bold" />
-            <Label fx:id="aliasLabel" styleClass="detail-label" />
+            <Label fx:id="aliasLabel" styleClass="detail-label" wrapText="true" maxWidth="270"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Course:" styleClass="detail-label-bold" />
-            <Label fx:id="courseLabel" styleClass="detail-label" />
+            <Label fx:id="courseLabel" styleClass="detail-label" wrapText="true" maxWidth="250"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Note:" styleClass="detail-label-bold" />
-            <Label fx:id="noteLabel" styleClass="detail-label" />
+            <Label fx:id="noteLabel" styleClass="detail-label" wrapText="true" maxWidth="270"/>
         </HBox>
         <HBox spacing="5">
             <Label text="Website:" styleClass="detail-label-bold" />
-            <Label fx:id="websiteLabel" styleClass="detail-label" />
+            <Label fx:id="websiteLabel" styleClass="detail-label" wrapText="true" maxWidth="250"/>
         </HBox>
     </VBox>
 </VBox>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/305ef960-1cb5-46a0-88da-2285eaa84b50)
- Removed the gaps between name and telegram if number was null in Person card
- Reordered telegram to the top of PersonDetailList
- If the fields are null, "-" is shown instead

![image](https://github.com/user-attachments/assets/b63251e7-b888-461e-8a50-86b07e3c7ca8)
- wrapping of text if they are too long