### PR TITLE
Fix detail panel bug and set min width

### DIFF
--- a/src/main/java/nusconnect/ui/MainWindow.java
+++ b/src/main/java/nusconnect/ui/MainWindow.java
@@ -149,6 +149,8 @@ public class MainWindow extends UiPart<Stage> {
     private void setWindowDefaultSize(GuiSettings guiSettings) {
         primaryStage.setHeight(guiSettings.getWindowHeight());
         primaryStage.setWidth(guiSettings.getWindowWidth());
+        primaryStage.setMinWidth(700);
+        primaryStage.setMinHeight(600);
         if (guiSettings.getWindowCoordinates() != null) {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());

--- a/src/main/java/nusconnect/ui/MainWindow.java
+++ b/src/main/java/nusconnect/ui/MainWindow.java
@@ -130,10 +130,8 @@ public class MainWindow extends UiPart<Stage> {
 
         personListPanel.getPersonListView().getSelectionModel().selectedItemProperty().addListener((
                 observable, oldValue, newValue) -> {
-                    if (newValue != null) {
-                        personDetailsPanel.setPersonDetails(newValue);
-                    }
-                });
+            personDetailsPanel.setPersonDetails(newValue);
+        });
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());


### PR DESCRIPTION
Changes made
- refresh `PersonDetailPanel` even when `Person` is null so that when there are no Person it will show default
- set the min width so that UI will not be covered