### PR TITLE
Change tele prefix to t instead of tele

### DIFF
--- a/src/main/java/nusconnect/logic/parser/CliSyntax.java
+++ b/src/main/java/nusconnect/logic/parser/CliSyntax.java
@@ -13,7 +13,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ALIAS = new Prefix("a/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
     public static final Prefix PREFIX_NOTE = new Prefix("no/");
-    public static final Prefix PREFIX_TELEGRAM = new Prefix("tele/");
+    public static final Prefix PREFIX_TELEGRAM = new Prefix("t/");
     public static final Prefix PREFIX_WEBSITE = new Prefix("w/");
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
 


### PR DESCRIPTION
All other prefix are single letter

Let's change prefix from tele to t

Prefix for telegram is too long and can be shorten