### PR TITLE
Fix trailing spaces and capitalisation of same names

### DIFF
--- a/src/main/java/nusconnect/model/person/Name.java
+++ b/src/main/java/nusconnect/model/person/Name.java
@@ -56,7 +56,8 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return this.fullName.trim().toLowerCase().replaceAll(" ", "")
+                .equals(otherName.fullName.trim().toLowerCase().replaceAll(" ", ""));
     }
 
     @Override

--- a/src/test/java/nusconnect/model/person/PersonTest.java
+++ b/src/test/java/nusconnect/model/person/PersonTest.java
@@ -5,6 +5,7 @@ import static nusconnect.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_MODULE_CS2103T;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_MODULE_CS2106;
+import static nusconnect.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -55,13 +56,13 @@ public class PersonTest {
         assertFalse(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_AMY.toLowerCase()).build();
         assertFalse(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Same name with different capitalisation or trailing whitespaces are wrong

Let's fix it by ensuring they are the same name

Fix it under person.equal where the names with trailing spaces and capitailisation are removed before checking