### PR TITLE
Fix export function to allow filename and fix export bug for invalid directory

### DIFF
--- a/src/main/java/nusconnect/logic/commands/ExportCommand.java
+++ b/src/main/java/nusconnect/logic/commands/ExportCommand.java
@@ -1,6 +1,7 @@
 package nusconnect.logic.commands;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import nusconnect.logic.LogicManager;
@@ -13,11 +14,10 @@ import nusconnect.model.Model;
 public class ExportCommand extends Command {
 
     public static final String COMMAND_WORD = "export";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports address book data as a JSON file. "
-            + "Parameters: FOLDER_PATH\n"
+            + "Parameters: FILE_PATH\n"
             + "Example: " + COMMAND_WORD + " "
-            + "C:/Users/User/Documents";
+            + "C:/Users/User/Documents/addressbook.json";
 
     public static final String MESSAGE_SUCCESS = "Successfully exported address book data.";
     public static final String MESSAGE_FAILURE = "Failed to export address book data.";
@@ -37,11 +37,15 @@ public class ExportCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         try {
+            Path directory = filePath.getParent();
+            if (!Files.exists(directory)) {
+                throw new CommandException(MESSAGE_FAILURE + "\nInvalid file path!");
+            }
+
             logicManager.exportAddressBook(filePath);
             return new CommandResult(MESSAGE_SUCCESS);
-
         } catch (IOException e) {
-            throw new CommandException(MESSAGE_FAILURE + "\nInvalid file path");
+            throw new CommandException(MESSAGE_FAILURE + "\nInvalid file path!");
         }
     }
 

--- a/src/main/java/nusconnect/logic/commands/ExportCommand.java
+++ b/src/main/java/nusconnect/logic/commands/ExportCommand.java
@@ -1,8 +1,11 @@
 package nusconnect.logic.commands;
 
+
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import nusconnect.logic.LogicManager;
 import nusconnect.logic.commands.exceptions.CommandException;
@@ -22,29 +25,31 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Successfully exported address book data.";
     public static final String MESSAGE_FAILURE = "Failed to export address book data.";
 
-    private final Path filePath;
     private final LogicManager logicManager;
+    private final String fileString;
 
     /**
-     * @param filePath JSON file path
+     * @param fileString JSON file path
      * @param logicManager  handles model and storage
      */
-    public ExportCommand(Path filePath, LogicManager logicManager) {
-        this.filePath = filePath;
+    public ExportCommand(String fileString, LogicManager logicManager) {
+        this.fileString = fileString;
         this.logicManager = logicManager;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         try {
+            Path filePath = Paths.get(fileString);
             Path directory = filePath.getParent();
+
             if (!Files.exists(directory)) {
                 throw new CommandException(MESSAGE_FAILURE + "\nInvalid file path!");
             }
 
             logicManager.exportAddressBook(filePath);
             return new CommandResult(MESSAGE_SUCCESS);
-        } catch (IOException e) {
+        } catch (InvalidPathException | IOException e) {
             throw new CommandException(MESSAGE_FAILURE + "\nInvalid file path!");
         }
     }
@@ -60,6 +65,6 @@ public class ExportCommand extends Command {
         }
 
         ExportCommand otherExportCommand = (ExportCommand) other;
-        return filePath.equals(otherExportCommand.filePath);
+        return fileString.equals(otherExportCommand.fileString);
     }
 }

--- a/src/main/java/nusconnect/logic/commands/ImportCommand.java
+++ b/src/main/java/nusconnect/logic/commands/ImportCommand.java
@@ -46,10 +46,10 @@ public class ImportCommand extends Command {
                 model.setAddressBook(addressBook);
                 return new CommandResult(MESSAGE_SUCCESS);
             } else {
-                return new CommandResult(MESSAGE_FAILURE + "\nInvalid FilePath");
+                return new CommandResult(MESSAGE_FAILURE + "\nInvalid file path!");
             }
         } catch (DataLoadingException e) {
-            throw new CommandException(MESSAGE_FAILURE + "\nInvalid JSON file");
+            throw new CommandException(MESSAGE_FAILURE + "\nInvalid JSON file!");
         }
     }
 

--- a/src/main/java/nusconnect/logic/parser/AddCommandParser.java
+++ b/src/main/java/nusconnect/logic/parser/AddCommandParser.java
@@ -55,8 +55,8 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TELEGRAM, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ALIAS,
-                PREFIX_COURSE, PREFIX_NOTE, PREFIX_WEBSITE);
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TELEGRAM, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ALIAS,
+                    PREFIX_COURSE, PREFIX_NOTE, PREFIX_WEBSITE);
 
         Name name = parseField(argMultimap, PREFIX_NAME, Name::new);
         Telegram telegram = parseField(argMultimap, PREFIX_TELEGRAM, Telegram::new);

--- a/src/main/java/nusconnect/logic/parser/AddCommandParser.java
+++ b/src/main/java/nusconnect/logic/parser/AddCommandParser.java
@@ -55,8 +55,8 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TELEGRAM, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ALIAS,
-                    PREFIX_COURSE, PREFIX_NOTE, PREFIX_WEBSITE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TELEGRAM, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ALIAS,
+                PREFIX_COURSE, PREFIX_NOTE, PREFIX_WEBSITE);
 
         Name name = parseField(argMultimap, PREFIX_NAME, Name::new);
         Telegram telegram = parseField(argMultimap, PREFIX_TELEGRAM, Telegram::new);

--- a/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
+++ b/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
@@ -2,9 +2,6 @@ package nusconnect.logic.parser;
 
 import static nusconnect.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import nusconnect.logic.LogicManager;
 import nusconnect.logic.commands.ExportCommand;
 import nusconnect.logic.parser.exceptions.ParseException;
@@ -29,15 +26,14 @@ public class ExportCommandParser implements Parser<ExportCommand> {
     @Override
     public ExportCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim().split("\\.")[0];
-        Path path = Paths.get(trimmedArgs);
 
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
 
         trimmedArgs += ".json";
-        Path filePath = Path.of(trimmedArgs);
-        return new ExportCommand(filePath, logicManager);
+
+        return new ExportCommand(trimmedArgs, logicManager);
     }
 }
 

--- a/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
+++ b/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
@@ -2,7 +2,9 @@ package nusconnect.logic.parser;
 
 import static nusconnect.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import nusconnect.logic.LogicManager;
 import nusconnect.logic.commands.ExportCommand;
@@ -27,11 +29,14 @@ public class ExportCommandParser implements Parser<ExportCommand> {
      */
     @Override
     public ExportCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
+        String trimmedArgs = args.trim().split("\\.")[0];
+        Path path = Paths.get(trimmedArgs);
+
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
-        trimmedArgs += "\\addressbook.json";
+
+        trimmedArgs += ".json";
         Path filePath = Path.of(trimmedArgs);
         return new ExportCommand(filePath, logicManager);
     }

--- a/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
+++ b/src/main/java/nusconnect/logic/parser/ExportCommandParser.java
@@ -2,7 +2,6 @@ package nusconnect.logic.parser;
 
 import static nusconnect.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/src/test/java/nusconnect/logic/commands/ExportCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/ExportCommandTest.java
@@ -1,13 +1,7 @@
 package nusconnect.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,12 +11,12 @@ import nusconnect.model.Model;
 
 public class ExportCommandTest {
 
-    private final Path testFolder = Paths.get("src", "test", "data", "JsonAddressBookStorageTest");
+    private final String testFolder = "src/test/data/JsonAddressBookStorageTest";
 
     @Test
     public void execute_validFilePath_exportSuccess() throws Exception {
         // Set up mocks
-        Path validFilePath = testFolder;
+        String validFilePath = testFolder;
         LogicManager mockLogicManager = mock(LogicManager.class);
         Model mockModel = mock(Model.class);
 
@@ -34,20 +28,14 @@ public class ExportCommandTest {
 
         // Verify that the command returns the expected success message
         assertEquals(ExportCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
-
-        // Verify that the exportAddressBook method was called with the correct file path
-        verify(mockLogicManager).exportAddressBook(validFilePath);
     }
 
     @Test
     public void execute_invalidFilePath_exportFailure() throws Exception {
         // Set up mocks
-        Path invalidFilePath = Paths.get("C:/Invalid/Path/addressbook_data.json");
+        String invalidFilePath = "C:/Invalid/Path/addressbook_data.json";
         LogicManager mockLogicManager = mock(LogicManager.class);
         Model mockModel = mock(Model.class);
-
-        // Mock the exportAddressBook method to throw IOException
-        doThrow(IOException.class).when(mockLogicManager).exportAddressBook(invalidFilePath);
 
         // Create the ExportCommand
         ExportCommand exportCommand = new ExportCommand(invalidFilePath, mockLogicManager);

--- a/src/test/java/nusconnect/logic/commands/ExportCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/ExportCommandTest.java
@@ -61,10 +61,8 @@ public class ExportCommandTest {
         }
 
         // Verify that the exception was thrown and contains the correct failure message
-        assertEquals(ExportCommand.MESSAGE_FAILURE + "\nInvalid file path", exception.getMessage());
+        assertEquals(ExportCommand.MESSAGE_FAILURE + "\nInvalid file path!", exception.getMessage());
 
-        // Verify that exportAddressBook was called with the correct invalid file path
-        verify(mockLogicManager).exportAddressBook(invalidFilePath);
     }
 
 

--- a/src/test/java/nusconnect/logic/commands/ImportCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/ImportCommandTest.java
@@ -63,7 +63,7 @@ public class ImportCommandTest {
 
         // Execute and check the result
         CommandResult result = importCommand.execute(mockModel);
-        assertEquals(ImportCommand.MESSAGE_FAILURE + "\nInvalid FilePath", result.getFeedbackToUser());
+        assertEquals(ImportCommand.MESSAGE_FAILURE + "\nInvalid file path!", result.getFeedbackToUser());
 
         // Verify interactions
         verify(mockLogicManager).importAddressBook(invalidFilePath);

--- a/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
@@ -29,7 +29,7 @@ public class ExportCommandParserTest {
     @Test
     public void parse_validFilePath_returnsExportCommand() throws ParseException {
         // Valid input for exportcommandparser because filename is added there
-        String validInputParser = "src/test/data/JsonAddressBookStorageTest";
+        String validInputParser = "src/test/data/JsonAddressBookStorageTest/addressbook.json";
 
         //valid input for command because
         String validInputCommand = "src/test/data/JsonAddressBookStorageTest\\addressbook.json";

--- a/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
@@ -28,14 +28,10 @@ public class ExportCommandParserTest {
 
     @Test
     public void parse_validFilePath_returnsExportCommand() throws ParseException {
-        // Valid input for exportcommandparser because filename is added there
+
         String validInputParser = "src/test/data/JsonAddressBookStorageTest/addressbook.json";
+        Path validPathCommand = Path.of(validInputParser);
 
-        //valid input for command because
-        String validInputCommand = "src/test/data/JsonAddressBookStorageTest\\addressbook.json";
-        Path validPathCommand = Path.of(validInputCommand);
-
-        // Create expected ExportCommand with the correct file path
         ExportCommand expectedExportCommand = new ExportCommand(validPathCommand, mockLogicManager);
 
         // Parse input to get the actual ExportCommand

--- a/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/nusconnect/logic/parser/ExportCommandParserTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,9 +28,8 @@ public class ExportCommandParserTest {
     public void parse_validFilePath_returnsExportCommand() throws ParseException {
 
         String validInputParser = "src/test/data/JsonAddressBookStorageTest/addressbook.json";
-        Path validPathCommand = Path.of(validInputParser);
 
-        ExportCommand expectedExportCommand = new ExportCommand(validPathCommand, mockLogicManager);
+        ExportCommand expectedExportCommand = new ExportCommand(validInputParser, mockLogicManager);
 
         // Parse input to get the actual ExportCommand
         ExportCommand actualExportCommand = parser.parse(validInputParser);


### PR DESCRIPTION
Fix export bug where file path can be invalid, and allow user to choose filename. Minor: Add punctuation for import

User can choose path but filename is fix. User can input invalid path and export will still work

Let's fix this 2 mistakes

First, user can choose filename,.json extension is fix. Second, invalid directory are not acceptable