### PR TITLE
Fix sort base on capitalisation

### DIFF
--- a/src/main/java/nusconnect/model/person/UniquePersonList.java
+++ b/src/main/java/nusconnect/model/person/UniquePersonList.java
@@ -102,7 +102,7 @@ public class UniquePersonList implements Iterable<Person> {
      * Sorts {@code persons} in the list by the names in alphanumerical order
      */
     public void sortPersonByName() {
-        internalList.sort(Comparator.comparing(person -> person.getName().toString()));
+        internalList.sort(Comparator.comparing(person -> person.getName().toString().toLowerCase()));
     }
 
     /**


### PR DESCRIPTION
Sort function sorts capital letter first then small, leading to John, aohn etc

Let's fix it by not looking at capitalisation

Make all string lowercase before sorting