### PR TITLE
Fix edit command resetting PersonDetailPanel

### DIFF
--- a/src/main/java/nusconnect/logic/commands/CommandResult.java
+++ b/src/main/java/nusconnect/logic/commands/CommandResult.java
@@ -67,7 +67,7 @@ public class CommandResult {
         return exit;
     }
 
-    public boolean isViewCommand() {
+    public boolean isSelectionRequired() {
         return personToSelect != null;
     }
 
@@ -89,7 +89,9 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && Objects.equals(personToSelect,
+                otherCommandResult.personToSelect);
     }
 
     @Override
@@ -103,6 +105,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("personToSelect", personToSelect)
                 .toString();
     }
 

--- a/src/main/java/nusconnect/logic/commands/EditCommand.java
+++ b/src/main/java/nusconnect/logic/commands/EditCommand.java
@@ -96,7 +96,8 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.format(editedPerson)), index);
     }
 
     /**

--- a/src/main/java/nusconnect/ui/MainWindow.java
+++ b/src/main/java/nusconnect/ui/MainWindow.java
@@ -128,10 +128,9 @@ public class MainWindow extends UiPart<Stage> {
         personDetailsPanel = new PersonDetailsPanel();
         personDetailsPanelPlaceholder.getChildren().add(personDetailsPanel.getRoot());
 
-        personListPanel.getPersonListView().getSelectionModel().selectedItemProperty().addListener((
-                observable, oldValue, newValue) -> {
-            personDetailsPanel.setPersonDetails(newValue);
-        });
+        personDetailsPanel.bindSelectedPerson(
+                personListPanel.getPersonListView().getSelectionModel().selectedItemProperty()
+        );
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -189,6 +188,14 @@ public class MainWindow extends UiPart<Stage> {
         return personListPanel;
     }
 
+    private void handleView(CommandResult commandResult) {
+        Index targetIndex = commandResult.getPersonToSelect();
+        int index = targetIndex.getZeroBased();
+        if (index < personListPanel.getPersonListView().getItems().size()) {
+            personListPanel.getPersonListView().getSelectionModel().select(index);
+        }
+    }
+
     /**
      * Executes the command and returns the result.
      *
@@ -208,13 +215,10 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            if (commandResult.isViewCommand()) {
-                Index targetIndex = commandResult.getPersonToSelect();
-                int index = targetIndex.getZeroBased();
-                if (index < personListPanel.getPersonListView().getItems().size()) {
-                    personListPanel.getPersonListView().getSelectionModel().select(index);
-                }
+            if (commandResult.isSelectionRequired()) {
+                handleView(commandResult);
             }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);

--- a/src/main/java/nusconnect/ui/PersonDetailsPanel.java
+++ b/src/main/java/nusconnect/ui/PersonDetailsPanel.java
@@ -2,6 +2,7 @@ package nusconnect.ui;
 
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
@@ -57,7 +58,7 @@ public class PersonDetailsPanel extends UiPart<Region> {
     /**
      * Updates the UI with the details of the given {@code person}.
      */
-    public void setPersonDetails(Person person) {
+    private void setPersonDetails(Person person) {
         if (person != null) {
             nameLabel.setText(person.getName().fullName);
             telegramLabel.setText(person.getTelegram().value);
@@ -70,5 +71,15 @@ public class PersonDetailsPanel extends UiPart<Region> {
         } else {
             setDefaultDetails();
         }
+    }
+
+    /**
+     * Binds the UI to the given {@code selectedPersonProperty} so that the person details
+     * are automatically updated when a new person is selected.
+     */
+    public void bindSelectedPerson(ObservableValue<Person> selectedPerson) {
+        selectedPerson.addListener((observable, oldValue, newValue) -> {
+            setPersonDetails(newValue);
+        });
     }
 }

--- a/src/test/java/nusconnect/logic/commands/CommandResultTest.java
+++ b/src/test/java/nusconnect/logic/commands/CommandResultTest.java
@@ -57,7 +57,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", personToSelect=" + commandResult.getPersonToSelect() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/nusconnect/logic/commands/EditCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/EditCommandTest.java
@@ -41,11 +41,11 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
-
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, INDEX_FIRST);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -62,11 +62,12 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, indexLastPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -75,10 +76,11 @@ public class EditCommandTest {
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, INDEX_FIRST);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -91,11 +93,12 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, INDEX_FIRST);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/nusconnect/logic/commands/ViewCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/ViewCommandTest.java
@@ -32,9 +32,11 @@ public class ViewCommandTest {
         String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS,
                 Messages.format(personToView));
 
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, INDEX_FIRST);
+
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        assertCommandSuccess(viewCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(viewCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -55,10 +57,12 @@ public class ViewCommandTest {
         String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS,
                 Messages.format(personToView));
 
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, INDEX_FIRST);
+
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST);
 
-        assertCommandSuccess(viewCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(viewCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Main Changes
- Moved listener logic from `MainWindow` to `PersonDetailPanel`
- Due to the `edit` command, the `Person` object at the currently selected index is completely replaced with a different `Person`. This might cause `ListView` to lose its selection. Solution: The `EditCommand` needs to explicitly tell the `MainWindow` which person should be selected after the edit is successfully completed