### PR TITLE
Update regex rule for module names

### DIFF
--- a/src/main/java/nusconnect/model/module/Module.java
+++ b/src/main/java/nusconnect/model/module/Module.java
@@ -9,9 +9,9 @@ import static java.util.Objects.requireNonNull;
 public class Module {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Module names should be alphanumeric, starting with 2~3 alphabets, followed by 4 numeric characters, "
-                    + "and followed by an optional character.";
-    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}[0-9]{4}[A-Za-z]?$";
+            "Module names should be alphanumeric, starting with 2~4 alphabets, followed by 4 numeric characters, "
+                    + "and followed by one or two optional characters.";
+    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,4}[0-9]{4}[A-Za-z]{0,2}$";
 
     public final String moduleName;
 

--- a/src/main/java/nusconnect/model/module/Module.java
+++ b/src/main/java/nusconnect/model/module/Module.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Represents a Module in the address book.
- * Guarantees: immutable; name is valid as declared in {@link #isValidModuleName(String)}
+ * Guarantees: immutable; name is valid as declared in {@link #isValidModuleName(Module)}
  */
 public class Module {
 

--- a/src/test/java/nusconnect/model/module/ModuleTest.java
+++ b/src/test/java/nusconnect/model/module/ModuleTest.java
@@ -29,17 +29,23 @@ public class ModuleTest {
 
         // invalid parts
         assertFalse(Module.isValidModuleName(new Module("C2106"))); // 1st alphabetic part below limit
-        assertFalse(Module.isValidModuleName(new Module("COMP2106"))); // 1st alphabetic part above limit
-        assertFalse(Module.isValidModuleName(new Module("CS2103TE"))); // 2nd alphabetic part above limit
+        assertFalse(Module.isValidModuleName(new Module("COMPS2106"))); // 1st alphabetic part above limit
+        assertFalse(Module.isValidModuleName(new Module("CS2103TEN"))); // 2nd alphabetic part above limit
         assertFalse(Module.isValidModuleName(new Module("CS424"))); // numeric part below limit
         assertFalse(Module.isValidModuleName(new Module("CS42488"))); // numeric part above limit
         assertFalse(Module.isValidModuleName(new Module("CS.2103/T"))); // illegal characters
+        assertFalse(Module.isValidModuleName(new Module("C0MP2106T3"))); // numeric char in alphabetic part
 
         // valid module name
         assertTrue(Module.isValidModuleName(new Module("CS4248"))); // 2A4N
         assertTrue(Module.isValidModuleName(new Module("CS2103T"))); // 2A4N1A
+        assertTrue(Module.isValidModuleName(new Module("EL4216HM"))); // 2A4N2A
         assertTrue(Module.isValidModuleName(new Module("GEC1039"))); // 3A4N
-        assertTrue(Module.isValidModuleName(new Module("LAN9988A"))); // 3A4N1A
+        assertTrue(Module.isValidModuleName(new Module("LSM2191A"))); // 3A4N1A
+        assertTrue(Module.isValidModuleName(new Module("PLS8002GE"))); // 3A4N2A
+        assertTrue(Module.isValidModuleName(new Module("GESS1000"))); // 4A4N
+        assertTrue(Module.isValidModuleName(new Module("GESS1000T"))); // 4A4N1A
+        assertTrue(Module.isValidModuleName(new Module("GESS1000TN"))); // 4A4N2A
         assertTrue(Module.isValidModuleName(new Module("ma2201"))); // lowercase characters
         assertTrue(Module.isValidModuleName(new Module("gEx1138f"))); // lowercase characters
     }


### PR DESCRIPTION
Allow 2-4 alphabetic + 4 numberic + 0-2 alphabetic module names. Resolve #164 