### PR TITLE
Duplicate persons have same name or phone or telegram

### DIFF
--- a/src/main/java/nusconnect/logic/commands/EditCommand.java
+++ b/src/main/java/nusconnect/logic/commands/EditCommand.java
@@ -91,7 +91,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (model.hasPersonExcludes(personToEdit, editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/nusconnect/logic/commands/EditCommand.java
+++ b/src/main/java/nusconnect/logic/commands/EditCommand.java
@@ -91,7 +91,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (model.hasPerson(editedPerson) && !personToEdit.isSamePerson(editedPerson)) {
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/nusconnect/logic/commands/EditCommand.java
+++ b/src/main/java/nusconnect/logic/commands/EditCommand.java
@@ -91,7 +91,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (model.hasPerson(editedPerson) && !personToEdit.isSamePerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/nusconnect/model/AddressBook.java
+++ b/src/main/java/nusconnect/model/AddressBook.java
@@ -1,6 +1,7 @@
 package nusconnect.model;
 
 import static java.util.Objects.requireNonNull;
+import static nusconnect.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -80,6 +81,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return persons.contains(person);
+    }
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book
+     * excluding {@code excludedPerson}.
+     */
+    public boolean hasPersonExcludes(Person excludedPerson, Person person) {
+        requireAllNonNull(excludedPerson, person);
+        return persons.containsExclude(excludedPerson, person);
     }
 
     /**

--- a/src/main/java/nusconnect/model/Model.java
+++ b/src/main/java/nusconnect/model/Model.java
@@ -1,5 +1,6 @@
 package nusconnect.model;
 
+
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
@@ -60,6 +61,12 @@ public interface Model {
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book
+     * excluding {@code excludedPerson}.
+     */
+    boolean hasPersonExcludes(Person excludedPerson, Person person);
 
     /**
      * Deletes the given person.

--- a/src/main/java/nusconnect/model/ModelManager.java
+++ b/src/main/java/nusconnect/model/ModelManager.java
@@ -96,6 +96,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPersonExcludes(Person excludedPerson, Person person) {
+        requireAllNonNull(excludedPerson, person);
+        return addressBook.hasPersonExcludes(excludedPerson, person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
 

--- a/src/main/java/nusconnect/model/person/Person.java
+++ b/src/main/java/nusconnect/model/person/Person.java
@@ -105,8 +105,6 @@ public class Person {
         if (otherPerson == this) {
             return true;
         }
-        System.out.println("This name: " + this.getName());
-        System.out.println("Other name: " + otherPerson.getName());
 
         return otherPerson != null
                 && (otherPerson.getName().equals(getName())

--- a/src/main/java/nusconnect/model/person/Person.java
+++ b/src/main/java/nusconnect/model/person/Person.java
@@ -106,10 +106,19 @@ public class Person {
             return true;
         }
 
-        return otherPerson != null
-                && (otherPerson.getName().equals(getName())
-                || otherPerson.getPhone().equals(getPhone())
-                || otherPerson.getTelegram().equals(getTelegram()));
+        if (otherPerson == null) {
+            return false; // Null check
+        }
+
+        // Check if name or telegram is the same
+        boolean isNameEqual = otherPerson.getName().equals(this.getName());
+        boolean isTelegramEqual = otherPerson.getTelegram().equals(this.getTelegram());
+
+        // Check phone equality only if at least one phone is not null
+        boolean isPhoneEqual = (this.getPhone().isPresent() && otherPerson.getPhone().isPresent())
+                && this.getPhone().get().equals(otherPerson.getPhone().get());
+
+        return isNameEqual || isTelegramEqual || isPhoneEqual;
     }
 
     /**

--- a/src/main/java/nusconnect/model/person/Person.java
+++ b/src/main/java/nusconnect/model/person/Person.java
@@ -107,14 +107,11 @@ public class Person {
         }
 
         if (otherPerson == null) {
-            return false; // Null check
+            return false;
         }
 
-        // Check if name or telegram is the same
         boolean isNameEqual = otherPerson.getName().equals(this.getName());
         boolean isTelegramEqual = otherPerson.getTelegram().equals(this.getTelegram());
-
-        // Check phone equality only if at least one phone is not null
         boolean isPhoneEqual = (this.getPhone().isPresent() && otherPerson.getPhone().isPresent())
                 && this.getPhone().get().equals(otherPerson.getPhone().get());
 

--- a/src/main/java/nusconnect/model/person/Person.java
+++ b/src/main/java/nusconnect/model/person/Person.java
@@ -105,6 +105,8 @@ public class Person {
         if (otherPerson == this) {
             return true;
         }
+        System.out.println("This name: " + this.getName());
+        System.out.println("Other name: " + otherPerson.getName());
 
         return otherPerson != null
                 && (otherPerson.getName().equals(getName())

--- a/src/main/java/nusconnect/model/person/Person.java
+++ b/src/main/java/nusconnect/model/person/Person.java
@@ -107,7 +107,9 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && (otherPerson.getName().equals(getName())
+                || otherPerson.getPhone().equals(getPhone())
+                || otherPerson.getTelegram().equals(getTelegram()));
     }
 
     /**

--- a/src/main/java/nusconnect/model/person/UniquePersonList.java
+++ b/src/main/java/nusconnect/model/person/UniquePersonList.java
@@ -38,6 +38,14 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains an equivalent person as the given argument without checking excluded person.
+     */
+    public boolean containsExclude(Person excludedPerson, Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(p -> !p.equals(excludedPerson) && p.isSamePerson(toCheck));
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/nusconnect/logic/commands/AddCommandTest.java
+++ b/src/test/java/nusconnect/logic/commands/AddCommandTest.java
@@ -145,6 +145,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasPersonExcludes(Person excludedPerson, Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasGroup(Group group) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/nusconnect/model/ModelManagerTest.java
+++ b/src/test/java/nusconnect/model/ModelManagerTest.java
@@ -4,6 +4,7 @@ import static nusconnect.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static nusconnect.testutil.Assert.assertThrows;
 import static nusconnect.testutil.TypicalPersons.ALICE;
 import static nusconnect.testutil.TypicalPersons.BENSON;
+import static nusconnect.testutil.TypicalPersons.BOB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,6 +87,24 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasPersonExcludes_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasPersonExcludes(null, null));
+    }
+
+    @Test
+    public void excludesSamePerson_returnsFalse() {
+        modelManager.addPerson(ALICE);
+        assertFalse(modelManager.hasPersonExcludes(ALICE, ALICE));
+    }
+
+    @Test
+    public void excludesDifferentPerson_returnsTrue() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+        assertTrue(modelManager.hasPersonExcludes(ALICE, BOB));
     }
 
     @Test

--- a/src/test/java/nusconnect/model/person/PersonTest.java
+++ b/src/test/java/nusconnect/model/person/PersonTest.java
@@ -5,7 +5,6 @@ import static nusconnect.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_MAJOR_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_MODULE_CS2103T;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_MODULE_CS2106;
-import static nusconnect.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
 import static nusconnect.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -51,18 +50,35 @@ public class PersonTest {
                 .build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        // same phone, all other attributes different -> returns true
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice)); // Same phone, different attributes
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_AMY.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // same telegram, all other attributes different -> returns true
+        editedAlice = new PersonBuilder(ALICE).withTelegram(VALID_TELEGRAM_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice)); // Same telegram, different attributes
 
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertTrue(BOB.isSamePerson(editedBob));
+        // same name, different telegram handle -> returns true
+        editedAlice = new PersonBuilder(ALICE).withTelegram(VALID_TELEGRAM_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice)); // Same name, different telegram
+
+        // same name, different phone number -> returns true
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice)); // Same name, different phone
+
+        // same name, different telegram handle and phone -> returns true
+        editedAlice = new PersonBuilder(ALICE)
+                .withTelegram(VALID_TELEGRAM_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .build();
+        assertTrue(ALICE.isSamePerson(editedAlice)); // Same name, different telegram and phone
+
+        editedAlice = new PersonBuilder(ALICE)
+                .withName(VALID_NAME_BOB) // Different name
+                .withPhone(VALID_PHONE_BOB) // Different phone
+                .withTelegram(VALID_TELEGRAM_BOB) // Different telegram
+                .build();
+        assertFalse(ALICE.isSamePerson(editedAlice)); // Should return false as all identifiers are different
     }
 
     @Test

--- a/src/test/java/nusconnect/model/person/PersonTest.java
+++ b/src/test/java/nusconnect/model/person/PersonTest.java
@@ -71,14 +71,19 @@ public class PersonTest {
                 .withTelegram(VALID_TELEGRAM_BOB)
                 .withPhone(VALID_PHONE_BOB)
                 .build();
-        assertTrue(ALICE.isSamePerson(editedAlice)); // Same name, different telegram and phone
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
+        // different name, different telegram handle, different phone -> returns false
         editedAlice = new PersonBuilder(ALICE)
-                .withName(VALID_NAME_BOB) // Different name
-                .withPhone(VALID_PHONE_BOB) // Different phone
-                .withTelegram(VALID_TELEGRAM_BOB) // Different telegram
+                .withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withTelegram(VALID_TELEGRAM_BOB)
                 .build();
-        assertFalse(ALICE.isSamePerson(editedAlice)); // Should return false as all identifiers are different
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // different name, different telegram handle, no phone -> returns false
+        editedAlice = new PersonBuilder(BOB).withTelegram(VALID_TELEGRAM_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
     }
 
     @Test


### PR DESCRIPTION
Blocks edit or adding of persons with same name or phone or telegram.
All same error message as "This person already exists in the address book!"